### PR TITLE
feature/freebsd-support-one: add include and endian.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ W        = -Wall
 OPT      = -O2 -g -I/usr/local/include
 STD      = -std=c++17
 CXXFLAGS = $(STD) $(OPT) $(W) -fPIC $(XCXXFLAGS)
-INCS     = -Isrc/ -I/usr/local/include
+INCS     = -Isrc/
 
 SRCS = src/Extensions.cpp src/Group.cpp src/Networking.cpp src/Hub.cpp src/Node.cpp src/WebSocket.cpp src/HTTPSocket.cpp src/Socket.cpp src/Epoll.cpp src/Room.cpp
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 W        = -Wall
-OPT      = -O2 -g
+OPT      = -O2 -g -I/usr/local/include
 STD      = -std=c++17
 CXXFLAGS = $(STD) $(OPT) $(W) -fPIC $(XCXXFLAGS)
-INCS     = -Isrc/
+INCS     = -Isrc/ -I/usr/local/include
 
 SRCS = src/Extensions.cpp src/Group.cpp src/Networking.cpp src/Hub.cpp src/Node.cpp src/WebSocket.cpp src/HTTPSocket.cpp src/Socket.cpp src/Epoll.cpp src/Room.cpp
 

--- a/src/Networking.h
+++ b/src/Networking.h
@@ -16,6 +16,10 @@
 #include <endian.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#endif
+
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
 #define htobe64(x) OSSwapHostToBigInt64(x)


### PR DESCRIPTION
while preferring the use of gnu as in gmake and g++ the posix c++ and make works as well in this case.  there is some Makefile fukery in that the obvious place to put the include addition did not work.
INCS     = -Isrc/ -I/usr/local/include
