### PR TITLE
fix(http): preserve leading ':' characters in header values

### DIFF
--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -22,7 +22,7 @@ char *getHeaders(char *buffer, char *end, Header *headers, size_t maxHeaders) {
             }
         } else {
             headers->keyLength = (unsigned int) (buffer - headers->key);
-            for (buffer++; (*buffer == ':' || *buffer < 33) && *buffer != '\r'; buffer++);
+            for (buffer++; *buffer < 33 && *buffer != '\r'; buffer++);
             headers->value = buffer;
             buffer = (char *) memchr(buffer, '\r', end - buffer); //for (; *buffer != '\r'; buffer++);
             if (buffer /*!= end*/ && buffer[1] == '\n') {


### PR DESCRIPTION
## Description

`getHeaders()` in `src/HTTPSocket.cpp` strips any `:` characters immediately following the key delimiter when skipping leading whitespace before a header value:
```cpp
for (buffer++; (*buffer == ':' || *buffer < 33) && *buffer != '\r'; buffer++);
```

## Issue
- Fixes https://github.com/hoytech/strfry/issues/216

## Fix
- Remove the `:` character only once, and only skip the optional whitespace characters after the header name

## Testing
<img width="2842" height="1599" alt="image" src="https://github.com/user-attachments/assets/0bee5b70-c6d5-4f30-9742-608365a37283" />
